### PR TITLE
[Deployment][Bug} Reseto automatico de nodemon fallaba

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,6 @@
+
+
+{
+"ignoreRoot": [".git"]
+}
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "start_demon": "nodemon server.js"
+    "start_demon": "nodemon server.js -e '*'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1.  Nodemon no se reseteaba por cambios en la carpeta de `node_modules`
2. Agregué archivo de configuracion de Nodemon, donde especificó que ignore el `.gitignore` y por doble negación ahora nodemon pone atención a la carpeta `node_modules`
3. Agregue `-e '*'` al script que corre nodemon, para que nodemon se resete si hay cambios en cualquier tipo de archivo, sin importar su terminación.  Antes solo checaba `.js, .json `
