### PR TITLE
Modificación a la página Inicio

### DIFF
--- a/views/css/home_style.css
+++ b/views/css/home_style.css
@@ -192,12 +192,12 @@ button {
 }
 
 @media only screen and (max-width: 767px) {
-     .img_box {
+     .img_boxInv {
           margin-top: 0px;
           margin-bottom: 0px;
      }
 
-     .img_box figure img {
+     .img_boxInv figure img {
           width: 0%;
      }
 }

--- a/views/pages/home.ejs
+++ b/views/pages/home.ejs
@@ -69,12 +69,12 @@
                         </div>
                      </div>
                      <div class="col-md-6">
-                        <div class="img_box">
+                        <div class="img_box img_boxInv">
                            <figure><img src="views/assets/Home/Deporte2.jpg" alt="#"/></figure>
                         </div>
                      </div>
                      <div class="col-md-6">
-                        <div class="img_box">
+                        <div class="img_box img_boxInv">
                            <figure><img src="views/assets/Home/Deporte3.jpg" alt="#"/></figure>
                         </div>
                      </div>


### PR DESCRIPTION
Antes en la versión móvil no se veían imágenes en el apartado de 'Disfruta y respeta', ahora se muestra sólo una imagen cuando se reduce de tamaño la página para no saturar demasiado.